### PR TITLE
refactor: add factory pattern for switching identity provider

### DIFF
--- a/books-auth/internal/adapters/factory.go
+++ b/books-auth/internal/adapters/factory.go
@@ -1,0 +1,43 @@
+package adapters
+
+import (
+	"fmt"
+
+	"github.com/edmartt/booktastic-auth-service/internal/adapters/auth0"
+	"github.com/edmartt/booktastic-auth-service/internal/core/ports"
+)
+
+type AuthProviderBundle struct {
+	Provider  ports.AuthProvider
+	Validator ports.TokenValidator
+}
+
+func NewAuthProvider(provider string) (*AuthProviderBundle, error) {
+	switch provider {
+	case "auth0":
+		config, err := auth0.LoadAuthConfig()
+
+		if err != nil {
+			return nil, err
+		}
+
+		validator, err := auth0.NewAuth0TokenValidator(config.Domain, config.Audience)
+
+		if err != nil {
+			return nil, err
+		}
+
+		auth0Provider, err := auth0.NewAuth0InitAPI(config.Domain, config.ClientID, config.ClientSecret, config.Auth0Connection, config.Audience)
+
+		if err != nil {
+			return nil, err
+		}
+		return &AuthProviderBundle{
+			Provider:  auth0Provider,
+			Validator: validator,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unkown auth provider: %s", provider)
+	}
+
+}

--- a/books-auth/main.go
+++ b/books-auth/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/edmartt/booktastic-auth-service/internal/adapters/auth0"
+	"github.com/edmartt/booktastic-auth-service/internal/adapters"
 	"github.com/edmartt/booktastic-auth-service/internal/adapters/http"
 	errorHandling "github.com/edmartt/booktastic-shared/errors/http/adapters/ginhttp"
 	"github.com/joho/godotenv"
@@ -15,26 +15,15 @@ func main() {
 		_ = godotenv.Load(".env")
 	}
 
-	auth0Config, err := auth0.LoadAuthConfig()
-
-	if err != nil {
-		panic(err)
-	}
-
-	validator, err := auth0.NewAuth0TokenValidator(auth0Config.Domain, auth0Config.Audience)
-
-	if err != nil {
-		panic(err)
-	}
-
-	authProvider, err := auth0.NewAuth0InitAPI(auth0Config.Domain, auth0Config.ClientID, auth0Config.ClientSecret, auth0Config.Auth0Connection, auth0Config.Audience)
+	authProvider, err := adapters.NewAuthProvider(os.Getenv("AUTH_PROVIDER"))
 
 	if err != nil {
 		panic(err)
 	}
 
 	errorHandler := errorHandling.NewGinErrors()
-	handler := http.NewHandler(validator, authProvider, *errorHandler)
+
+	handler := http.NewHandler(authProvider.Validator, authProvider.Provider, *errorHandler)
 
 	server := http.HTTPServer{
 		Handler: *handler,


### PR DESCRIPTION
- now we can switch between auth0 to maybe cognito or some other provider adding just new cases.
- provider with an env var instead of hardcoded name.